### PR TITLE
remove references to RAS

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,18 +28,17 @@ make up
 
 ## Slowstart
 
-There are 3 docker-compose files in this repository:
+There are 2 docker-compose files in this repository:
 - dev.yml - spins up the core development containers such as postgres, rabbit and sftp
-- ras-services.yml - spins up the python services such as partysvc-stub and collection-instrument
 - rm-services.yml - spins up the Java and Go services such as survey service and action service
 
 These can be run together as per the Quickstart section or individually.  Additionally individual services can be specified at the end of the command. For example:
 
 ```
-docker-compose -f dev.yml -f ras-services.yml up -d
+docker-compose -f dev.yml -f rm-services.yml up -d
 ```
 
-This will spin up the development containers and the ras-services.
+This will spin up the development containers and the rm-services.
 
 ```
 docker-compose -f rm-services.yml up -d collex
@@ -124,7 +123,7 @@ Some services aren't resilient to the database not being up before the service h
 
 ### Services running sluggishly?
 
-When ras/rm is all running it takes a lot of memory.  Click on the docker icon in the top bar of your Mac,
+When rm is all running it takes a lot of memory.  Click on the docker icon in the top bar of your Mac,
 then click on 'preferences', then go to the 'advanced' tab.  The default memory allocated to Docker is 2gb.
 Bumping that up to 8gb and the number of cores to 4 should make the service run much smoother. Note: These aren't
 hard and fast numbers, this is just what worked for people.


### PR DESCRIPTION
Remove any references to RAS service from the README.md as as it doesn't exist for census and is a bit misleading