### PR TITLE
Add docker config to dev docker-compose file

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -47,6 +47,8 @@ services:
   image: eu.gcr.io/census-ci/rm/census-rm-ops
   ports:
   - "8003:80"
+  environment:
+  - APP_SETTINGS=DockerConfig
  pubsub-emulator:
   container_name: pubsub-emulator
   image: eu.gcr.io/census-ci/gcloud-pubsub-emulator:latest


### PR DESCRIPTION
The rm-ops tool wasn't working as it was using the K8s config. This PR fixes that by setting the config in the rm-ops tool docker-compose file to DockerConfig.

How to test:
Bring up census-rm-docker-dev and navigate to the ops tool in your browser. The page should appear correctly.