### PR TITLE
Change details on ops container to census-rm-ops

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -42,8 +42,8 @@ services:
    - PGADMIN_DEFAULT_PASSWORD=secret
   links:
    - ons-postgres:postgres
- rasrm-ops:
-  container_name: rasrm-ops
+ census-rm-ops:
+  container_name: census-rm-ops
   image: eu.gcr.io/census-ci/rm/census-rm-ops
   ports:
   - "8003:80"


### PR DESCRIPTION
Updated details on the ops tool to change the name from rasrm-ops to census-rm-ops.

To test make sure you're pulling the latest image from GCR by either deleting whatever ops docker container you already have or doing a make pull up.
The ops tool should be called census-rm-ops when doing a docker ps and if it's a fresh docker deployment, there should be no surveys on the census-rm-ops default screen.