### PR TITLE
Adding caseapi service

### DIFF
--- a/.env
+++ b/.env
@@ -65,4 +65,4 @@ SUBSCRIPTION_NAME=rm-receipt-subscription
 
 # Case API
 CASE_API_HOST=caseapi
-CASE_API_PORT=8302
+CASE_API_PORT=8161

--- a/.env
+++ b/.env
@@ -62,3 +62,7 @@ RABBIT_ROUTE=Case.Responses.binding
 RABBIT_EXCHANGE=case-outbound-exchange
 RECEIPT_TOPIC_NAME=eq-submission-topic
 SUBSCRIPTION_NAME=rm-receipt-subscription
+
+# Case API
+CASE_API_HOST=caseapi
+CASE_API_PORT=8302

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -141,7 +141,7 @@ services:
     container_name: caseapi
     image: eu.gcr.io/census-rm-ci/rm/census-rm-case-api
     ports:
-      - "${CASE_API_PORT}:8302"
+      - "${CASE_API_PORT}:8161"
     external_links:
      - postgres
     environment:
@@ -150,7 +150,7 @@ services:
      - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
     restart: always
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8302/actuator/info"]
+      test: ["CMD", "curl", "-f", "http://localhost:8161/actuator/info"]
       interval: 1m30s
       timeout: 10s
       retries: 3

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -137,7 +137,6 @@ services:
       - SUBSCRIPTION_NAME=${SUBSCRIPTION_NAME}
     restart: always
 
-
   caseapi:
     container_name: caseapi
     image: eu.gcr.io/census-rm-ci/rm/census-rm-case-api

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -137,6 +137,26 @@ services:
       - SUBSCRIPTION_NAME=${SUBSCRIPTION_NAME}
     restart: always
 
+
+  caseapi:
+    container_name: caseapi
+    image: eu.gcr.io/census-rm-ci/rm/census-rm-case-api
+    ports:
+      - "${CASE_API_PORT}:8302"
+    external_links:
+     - postgres
+    environment:
+     - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres:${POSTGRES_PORT}/${POSTGRES_HOST}?sslmode=disable
+     - SPRING_DATASOURCE_USERNAME=${POSTGRES_USERNAME}
+     - SPRING_DATASOURCE_PASSWORD=${POSTGRES_PASSWORD}
+    restart: always
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8302/actuator/info"]
+      interval: 1m30s
+      timeout: 10s
+      retries: 3
+    
+
 networks:
   default:
     external:


### PR DESCRIPTION
Do not merge until the census-rm-case-api service is being built and pushed to the container repository.

### Motivation and Context
census-rm-case-api is a new service to allow the contact centre retrieve data about cases.

### What has changed
Added the new case-api service

### How to test?
`make up` and check the new service is running

### Links
[https://trello.com/c/Tg697scy/633-rmc-139-provide-case-look-up-for-cc-13](https://trello.com/c/Tg697scy/633-rmc-139-provide-case-look-up-for-cc-13)


