### PR TITLE
Restore network and create it automatically in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOT := $(shell command -v dot 2> /dev/null)
 
 up:
+	docker network inspect censusrmdockerdev_default >/dev/null || docker network create censusrmdockerdev_default
 	docker-compose -f dev.yml -f rm-services.yml up -d ${SERVICE} ;
 	pipenv install --dev
 	pipenv run python setup_database.py

--- a/README.md
+++ b/README.md
@@ -101,6 +101,16 @@ make: *** [up] Error 1
 ```
 - Kill the process hogging that port by running `lsof -n -i:8002|awk 'FNR == 2 { print $2 }'|xargs kill` where 8002 is the port you are trying to bind to
 
+### Docker network
+```
+ERROR: Network censusrmdockerdev_default declared as external, but could not be found. Please create the network manually using `docker network create censusrmdockerdev_default` and try again.
+make: *** [up] Error 1
+```
+
+- Run `docker network create censusrmdockerdev_default` to create the docker network.
+
+**NB:** Docker compose may warn you that the network is unused. This is a lie, it is in use. 
+
 ### Unexpected behavior
 
 1. Stop docker containers `make down`

--- a/dev.yml
+++ b/dev.yml
@@ -63,3 +63,6 @@ services:
     ports:
       - "8917:5000"
 
+networks:
+  censusrmdockerdev_default:
+    external: true

--- a/rm-services.yml
+++ b/rm-services.yml
@@ -235,3 +235,7 @@ services:
       retries: 4
       start_period: 30s
 
+networks:
+  default:
+    external:
+      name: censusrmdockerdev_default


### PR DESCRIPTION
# Motivation and Context
Despite the warnings claiming the network was unused it was actually in use. It can, however be created automatically in the makefile scripts removing the need for manual intervention when it's not already there.

# What has changed
* Restore censusrmdockerdev_default external network
* Create the network automatically in `make up` target
* Add warning in README to disregard the misleading logs that the network is unused

# How to test?
Delete the network if you still have it then run `make up`. It should now create the network for you rather than complain about it not existing. The unaddressed local docker AT's should also work once more.